### PR TITLE
Fix ReflectionHelper.GetValue with value type properties

### DIFF
--- a/Assets/Scripts/ReflectionHelper.cs
+++ b/Assets/Scripts/ReflectionHelper.cs
@@ -86,7 +86,7 @@ namespace KModkit
         		var fieldMember = type.GetCachedMember<FieldInfo>(member);
         		var propertyMember = type.GetCachedMember<PropertyInfo>(member);
         
-        		return (T) ((fieldMember != null ? fieldMember.GetValue(target) : default(T)) ?? (propertyMember != null ? propertyMember.GetValue(target, null) : default(T)));
+			return (T) (fieldMember != null ? fieldMember.GetValue(target) : propertyMember != null ? propertyMember.GetValue(target, null) : default(T));
         	}
         
         	public static void SetValue(this Type type, string member, object value, object target = null)


### PR DESCRIPTION
This commit fixes https://github.com/samfundev/KtaneTwitchPlays/issues/576 making `ReflectionHelper.GetValue` work properly when reading properties of non-nullable value types instead of returning 0.