### PR TITLE
Disable the VS warnings through .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+dotnet_diagnostic.IDE0034.severity = none
+dotnet_diagnostic.IDE0038.severity = none
+dotnet_diagnostic.RCS1244.severity = none

--- a/Assets/Scripts/ReflectionHelper.cs
+++ b/Assets/Scripts/ReflectionHelper.cs
@@ -97,7 +97,6 @@ public static class ReflectionHelper
     {
         // Use AssemblyQualifiedName and the member name as a unique key to prevent a collision if two types have the same member name
         var key = type.AssemblyQualifiedName + member;
-#pragma warning disable IDE0038
         if (MemberCache.ContainsKey(key)) return MemberCache[key] is T ? (T)MemberCache[key] : null;
 
         MemberInfo memberInfo = type.GetMember(member,
@@ -106,7 +105,6 @@ public static class ReflectionHelper
         MemberCache[key] = memberInfo;
 
         return memberInfo is T ? (T)memberInfo : null;
-#pragma warning restore IDE0038
     }
 
     public static T GetValue<T>(this Type type, string member, object target = null)
@@ -132,9 +130,7 @@ public static class ReflectionHelper
     public static T CallMethod<T>(this Type type, string method, object target = null, params object[] arguments)
     {
         var member = type.GetCachedMember<MethodInfo>(method);
-#pragma warning disable IDE0034, IDE0034WithoutSuggestion, RCS1244
         return member != null ? (T)member.Invoke(target, arguments) : default(T);
-#pragma warning restore IDE0034, IDE0034WithoutSuggestion, RCS1244
     }
 
     public static void CallMethod(this Type type, string method, object target = null, params object[] arguments)


### PR DESCRIPTION
Disable the VS warnings through .editorconfig instead of #pragma so that Unity stops complaining when they are not numbers.